### PR TITLE
Fixed a bug in ex1.1 of lab 8a

### DIFF
--- a/ex8a/ex1/ex1.1.s
+++ b/ex8a/ex1/ex1.1.s
@@ -2,5 +2,5 @@
 _start:
 	
 	MOV R0, #10
-    MOV R1, =0x20000000
+    MOV R1, #0x20000000
     STR R0, [R1]

--- a/ex8a/ex1/ex1.1.s
+++ b/ex8a/ex1/ex1.1.s
@@ -2,5 +2,5 @@
 _start:
 	
 	MOV R0, #10
-    MOV R1, #0x20000000
+    LDR R1, =0x20000000
     STR R0, [R1]


### PR DESCRIPTION
* with mov instruction, you should use `#` symbol, instead of `=`